### PR TITLE
added ValueError to Device.get_signal_index() if label does not exist

### DIFF
--- a/src/nimbalwear/data.py
+++ b/src/nimbalwear/data.py
@@ -211,6 +211,9 @@ class Device:
 
         index = None if index == len(self.signal_headers) else index
 
+        if index == None:
+            raise ValueError("Signal label does not exist")
+
         return index
 
     def get_day_idxs(self, day_offset):


### PR DESCRIPTION
Should change to a print statement if this will cause problems with the pipeline.